### PR TITLE
Added missing #include <tuple> to distances.h

### DIFF
--- a/src/distances.h
+++ b/src/distances.h
@@ -11,6 +11,7 @@
 #include <limits>
 #include <numeric>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "utils.h"


### PR DESCRIPTION
The original code compiled with some compilers but not others, depending on whether `<tuple>` happened to be included in one of the compiler's other header files (a related issue is discussed here: https://stackoverflow.com/questions/42285072/why-does-this-c-code-compile-with-some-compilers-but-not-others).